### PR TITLE
Adding Initializer with configuration for WBWKWebView in Examples

### DIFF
--- a/Examples/WKWebView+WBWebViewConsole/WKWebView+WBWebViewConsole/WBWKWebView.m
+++ b/Examples/WKWebView+WBWebViewConsole/WKWebView+WBWebViewConsole/WBWKWebView.m
@@ -37,6 +37,17 @@
     return self;
 }
 
+- (instancetype)initWithFrame:(CGRect)frame configuration:(WKWebViewConfiguration *)configuration {
+
+    if (self = [super initWithFrame:frame configuration:configuration]) {
+        self.navigationDelegate = self;
+        self.JSBridge = [[WBWebViewJSBridge alloc] initWithWebView:self];
+
+        self.console = [[WBWebViewConsole alloc] initWithWebView:self];
+    }
+    return self;
+}
+
 - (void)wb_addUserScript:(WBWebViewUserScript *)userScript
 {
     if (!userScript) {


### PR DESCRIPTION
For developers who want to try out the `WBWKWebView` implementation for use-cases requiring injection of JS scripts at document load start/end time, the `WKWebView` initializer with the additional `WKWebViewConfiguration` input parameter needs to be overridden. 

This was something that I needed when I used the Examples. Felt it could be of use to someone else and bring more consistency with the interfaces provided by the `WKWebView` sublclass.

Hence, adding the same in this PR.

Thank you.
